### PR TITLE
Fix inappropriate modification of animation keywords

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,8 +243,12 @@ function localizeAnimationShorthandDeclValues(decl, context) {
   };
 
   const didParseAnimationName = false;
-  const parsedAnimationKeywords = {};
+  let parsedAnimationKeywords = {};
   const valueNodes = valueParser(decl.value).walk((node) => {
+    /* If div-token appeared (represents as comma ','), a possibility of an animation-keywords should be reflesh. */
+    if (node.type === 'div') {
+      parsedAnimationKeywords = {};
+    }
     const value =
       node.type === 'word' ? node.value.toLowerCase() : null;
 

--- a/test.js
+++ b/test.js
@@ -192,6 +192,13 @@ const tests = [
       ':local(.foo) { animation: 1s normal ease-out infinite :local(foo); }'
   },
   {
+    should:
+      'not treat animation curve as identifier of animation name even if it separated by comma',
+    input: '.foo { animation: 1s normal ease-out infinite, 1s normal ease-out infinite; }',
+    expected:
+      ':local(.foo) { animation: 1s normal ease-out infinite, 1s normal ease-out infinite; }'
+  },
+  {
     should: 'handle animations with custom timing functions',
     input:
       '.foo { animation: 1s normal cubic-bezier(0.25, 0.5, 0.5. 0.75) foo; }',


### PR DESCRIPTION
It seems there is a case which handling animation-keywords as local-identifier.

Originally, the issue reported at [`css-loader`](https://github.com/webpack-contrib/css-loader/issues/872)
