### PR TITLE
Fix path to index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "postcss-modules-local-by-default",
   "version": "2.0.4",
   "description": "A CSS Modules transform to make local scope the default",
-  "main": "src/index.js",
+  "main": "index.js",
   "engines": {
     "node": ">= 6"
   },


### PR DESCRIPTION
Hello @evilebottnawi I propose this change to the package.json as the file isn't in the src folder.
And this currently breaks css-loader when used with Yarn PNP.