### PR TITLE
don't localize imported values in selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -469,7 +469,7 @@ module.exports = postcss.plugin('postcss-modules-local-by-default', function(
           atrule.params = localMatch[0];
           globalKeyframes = false;
         } else if (!globalMode) {
-          if (!localAliasMap.has(atrule.params))
+          if (atrule.params && !localAliasMap.has(atrule.params))
             atrule.params = ':local(' + atrule.params + ')';
         }
         atrule.walkDecls(function(decl) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "trailingComma": "es5"
   },
   "dependencies": {
+    "icss-utils": "^4.0.0",
     "postcss": "^7.0.6",
     "postcss-selector-parser": "^6.0.0",
     "postcss-value-parser": "^3.3.1"

--- a/test.js
+++ b/test.js
@@ -532,6 +532,74 @@ const tests = [
     input: ':root { --title-align: center; --sr-only: { position: absolute; } }',
     expected: ':root { --title-align: center; --sr-only: { position: absolute; } }',
   },
+  /**
+   * Imported aliases
+   */
+  {
+    should: 'not localize imported alias',
+    input: `
+      :import(foo) { a_value: some-value; }
+
+      .foo > .a_value { }
+    `,
+    expected: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.foo) > .a_value { }
+    `
+  },
+  {
+    should: 'not localize nested imported alias',
+    input: `
+      :import(foo) { a_value: some-value; }
+
+      .foo > .a_value > .bar { }
+    `,
+    expected: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.foo) > .a_value > :local(.bar) { }
+    `
+  },
+  {
+    should: 'not localize open ended imported alias',
+    input: `
+      :import(foo) { a_value: some-value; }
+
+      :local .foo .a_value .bar { }
+    `,
+    expected: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.foo) .a_value :local(.bar) { }
+    `
+  },
+  {
+    should: 'ignore imported in explicit local',
+    input: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.a_value) { }
+    `,
+    expected: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.a_value) { }
+    `
+  },
+  {
+    should: 'maintain explicit local',
+    input: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.a_value, .foo) .a_value { }
+    `,
+    expected: `
+      :import(foo) { a_value: some-value; }
+
+      :local(.a_value) :local(.foo) .a_value { }
+    `
+  }
 ];
 
 function process(css, options) {

--- a/test.js
+++ b/test.js
@@ -529,8 +529,10 @@ const tests = [
   },
   {
     should: 'not ignore custom property set',
-    input: ':root { --title-align: center; --sr-only: { position: absolute; } }',
-    expected: ':root { --title-align: center; --sr-only: { position: absolute; } }',
+    input:
+      ':root { --title-align: center; --sr-only: { position: absolute; } }',
+    expected:
+      ':root { --title-align: center; --sr-only: { position: absolute; } }',
   },
   /**
    * Imported aliases
@@ -546,7 +548,7 @@ const tests = [
       :import(foo) { a_value: some-value; }
 
       :local(.foo) > .a_value { }
-    `
+    `,
   },
   {
     should: 'not localize nested imported alias',
@@ -559,21 +561,9 @@ const tests = [
       :import(foo) { a_value: some-value; }
 
       :local(.foo) > .a_value > :local(.bar) { }
-    `
-  },
-  {
-    should: 'not localize open ended imported alias',
-    input: `
-      :import(foo) { a_value: some-value; }
-
-      :local .foo .a_value .bar { }
     `,
-    expected: `
-      :import(foo) { a_value: some-value; }
-
-      :local(.foo) .a_value :local(.bar) { }
-    `
   },
+
   {
     should: 'ignore imported in explicit local',
     input: `
@@ -585,21 +575,47 @@ const tests = [
       :import(foo) { a_value: some-value; }
 
       :local(.a_value) { }
-    `
+    `,
   },
   {
-    should: 'maintain explicit local',
+    should: 'escape local context with explict global',
     input: `
       :import(foo) { a_value: some-value; }
 
-      :local(.a_value, .foo) .a_value { }
+      :local .foo :global(.a_value) .bar { }
     `,
     expected: `
       :import(foo) { a_value: some-value; }
 
-      :local(.a_value) :local(.foo) .a_value { }
-    `
-  }
+      :local(.foo) .a_value :local(.bar) { }
+    `,
+  },
+  {
+    should: 'respect explicit local',
+    input: `
+      :import(foo) { a_value: some-value; }
+
+      .a_value :local .a_value .foo :global .a_value { }
+    `,
+    expected: `
+      :import(foo) { a_value: some-value; }
+
+      .a_value :local(.a_value) :local(.foo) .a_value { }
+    `,
+  },
+  {
+    should: 'not localize imported animation-name',
+    input: `
+      :import(file) { a_value: some-value; }
+
+      .foo { animation-name: a_value; }
+    `,
+    expected: `
+      :import(file) { a_value: some-value; }
+
+      :local(.foo) { animation-name: a_value; }
+    `,
+  },
 ];
 
 function process(css, options) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,6 +324,15 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1221,6 +1230,13 @@ iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+icss-utils@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.0.0.tgz#d52cf4bcdcfa1c45c2dbefb4ffdf6b00ef608098"
+  integrity sha512-bA/xGiwWM17qjllIs9X/y0EjsB7e0AV08F3OL8UPsoNkNRibIuu8f1eKTnQ8QO1DteKKTxTUAn+IEWUToIwGOA==
+  dependencies:
+    postcss "^7.0.5"
+
 ignore-walk@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
@@ -2098,6 +2114,15 @@ postcss-value-parser@^3.3.1:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
+postcss@^7.0.5:
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
+  integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@^7.0.6:
   version "7.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
@@ -2644,6 +2669,16 @@ supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+<<<<<<< HEAD
+=======
+  dependencies:
+    has-flag "^3.0.0"
+
+table@^5.0.2:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.1.1.tgz#92030192f1b7b51b6eeab23ed416862e47b70837"
+  integrity sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==
+>>>>>>> WIP
   dependencies:
     has-flag "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,15 +324,6 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2114,16 +2105,7 @@ postcss-value-parser@^3.3.1:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss@^7.0.5:
-  version "7.0.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
-  integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
-postcss@^7.0.6:
+postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.14.tgz#4527ed6b1ca0d82c53ce5ec1a2041c2346bbd6e5"
   integrity sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==
@@ -2669,16 +2651,6 @@ supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-<<<<<<< HEAD
-=======
-  dependencies:
-    has-flag "^3.0.0"
-
-table@^5.0.2:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.1.tgz#92030192f1b7b51b6eeab23ed416862e47b70837"
-  integrity sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==
->>>>>>> WIP
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
This PR adds support for using imported values as selectors. Previously if an imported value (like a class name) was used in a selector it would get replaces correctly, but then would be made `:local()` which ends up resulting in the classname getting hashed again later and removing the reference to the original value. 

This prevents that by treating an instance of a imported key in a selector as if it was global so that it's not localized. You can also avoid this behavior by explicitly making the selector `:local()`