### PR TITLE
Adds safety check before accessing "rule parent"

### DIFF
--- a/index.js
+++ b/index.js
@@ -494,6 +494,7 @@ module.exports = postcss.plugin('postcss-modules-local-by-default', function(
 
     css.walkRules(function(rule) {
       if (
+        rule.parent &&
         rule.parent.type === 'atrule' &&
         /keyframes$/i.test(rule.parent.name)
       ) {


### PR DESCRIPTION
Adds an explicit safety check when accessing properties of `rule.parent` instance.

> This fixes the issue I'm currently experiencing with the latest versions of all css-related dependencies installed. See #7 for more details from my side. Thanks.

## GitHub

- Fixes #7 