### PR TITLE
Treat :import and :export statements as pure. Fixes #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ function normalizeNodeArray(nodes) {
 function localizeNode(rule, mode, localAliasMap) {
   const isScopePseudo = node =>
     node.value === ':local' || node.value === ':global';
+  const isImportExportPseudo = node =>
+    node.value === ':import' || node.value === ':export';
 
   const transform = (node, context) => {
     if (context.ignoreNextSpacing && !isSpacing(node)) {
@@ -115,9 +117,12 @@ function localizeNode(rule, mode, localAliasMap) {
         let childContext;
         const isNested = !!node.length;
         const isScoped = isScopePseudo(node);
+        const isImportExport = isImportExportPseudo(node);
 
+        if (isImportExport) {
+          context.hasLocals = true;
         // :local(.foo)
-        if (isNested) {
+        } else if (isNested) {
           if (isScoped) {
             if (node.nodes.length === 0) {
               throw new Error(`${node.value}() can't be empty`);

--- a/test.js
+++ b/test.js
@@ -654,6 +654,18 @@ const tests = [
     error: /:global\(\) can't be empty/
   },
   */
+  {
+    should: 'consider :import statements pure',
+    input: ':import("~/lol.css") { foo: __foo; }',
+    options: { mode: 'pure' },
+    expected: ':import("~/lol.css") { foo: __foo; }',
+  },
+  {
+    should: 'consider :export statements pure',
+    input: ':export { foo: __foo; }',
+    options: { mode: 'pure' },
+    expected: ':export { foo: __foo; }',
+  },
 ];
 
 function process(css, options) {


### PR DESCRIPTION
This fixes #21 and would resolve the related next.js tickets vercel/next.js#10142 and vercel/next.js#11629.

It seems incorrect to use something called `context.useLocals` for this purpose, as way I am in this PR, but it's only used for the pure mode check, and I couldn't think of a more descriptive variable name. I'm open to any alternative approaches.