### PR TITLE
css nesting support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -230,6 +230,11 @@ function localizeNode(rule, mode, localAliasMap) {
 
         break;
       }
+      case "nesting": {
+        if (node.value === "&") {
+          context.hasLocals = true;
+        }
+      }
     }
 
     context.lastWasSpacing = false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -844,6 +844,12 @@ const tests = [
     input: ":global(.a:not(:global .b, :global .c)) {}",
     error: /A :global is not allowed inside of a :global/,
   },
+  {
+    name: "consider & statements as pure",
+    input: ".foo { &:hover { a_value: some-value; } }",
+    options: { mode: "pure" },
+    expected: ":local(.foo) { &:hover { a_value: some-value; } }",
+  },
   /*
   Bug in postcss-selector-parser
   {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -850,6 +850,24 @@ const tests = [
     options: { mode: "pure" },
     expected: ":local(.foo) { &:hover { a_value: some-value; } }",
   },
+  {
+    name: "consider selector & statements as pure",
+    input: ".foo { html &:hover { a_value: some-value; } }",
+    options: { mode: "pure" },
+    expected: ":local(.foo) { html &:hover { a_value: some-value; } }",
+  },
+  {
+    name: "consider selector & statements as pure",
+    input: ".foo { &:global(.bar) { a_value: some-value; } }",
+    options: { mode: "pure" },
+    expected: ":local(.foo) { &.bar { a_value: some-value; } }",
+  },
+  {
+    name: "throw on nested & selectors without a local selector",
+    input: ":global(.foo) { &:hover { a_value: some-value; } }",
+    options: { mode: "pure" },
+    error: /is not pure/,
+  },
   /*
   Bug in postcss-selector-parser
   {


### PR DESCRIPTION
today ~76% of all browsers support for css nesting: https://caniuse.com/css-nesting

therefore this pr adds tests:

- a test for `.foo { &:hover { a_value: some-value; } }` which is pure
- a test for `.foo { html &:hover { a_value: some-value; } }` which is pure
- a test for `.foo { &:global(.bar) { a_value: some-value; } }` which is pure
- a test for `:global(.foo) { &:hover { a_value: some-value; } }` which is **not** pure

this pr also adds logic to `localizeNode` to make the tests above pass

fixes #65 
