### PR TITLE
add test for current pure logic

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [lts/*]
+        node-version: ["lts/*"]
 
     runs-on: ${{ matrix.os }}
 
@@ -32,15 +32,17 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          architecture: "x64"
           cache: "yarn"
+          cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -54,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: ["10", "12", "14", "16", "18", "20"]
         webpack-version: [latest]
 
     runs-on: ${{ matrix.os }}
@@ -68,13 +70,15 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: git config --global core.autocrlf input
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "${{ matrix.node-version }}"
+          architecture: "x64"
           cache: "yarn"
+          cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -851,6 +851,12 @@ const tests = [
     expected: ":local(.foo) { &:hover { a_value: some-value; } }",
   },
   {
+    name: "consider global inside local as pure",
+    input: ".foo button { a_value: some-value; }",
+    options: { mode: "pure" },
+    expected: ":local(.foo) button { a_value: some-value; }",
+  },
+  {
     name: "consider selector & statements as pure",
     input: ".foo { html &:hover { a_value: some-value; } }",
     options: { mode: "pure" },


### PR DESCRIPTION
I created a small next.js demo project with the following css code:

```css
.page {
  button {
    color: green;
  }
}
```

[Stackblitz without postcss-nesting](https://stackblitz.com/edit/stackblitz-starters-2twhhj?file=app%2Fpage.module.css)
without postcss-nesting `.page {  button { .. } }` is not pure:

![shot-MPwBLLsD@2x](https://github.com/user-attachments/assets/90aebfa1-51da-44f8-a4a8-898d56a99b25)

however the same css code works once you add `postcss-nesting`

[Stackblitz with postcss-nesting](https://stackblitz.com/edit/stackblitz-starters-ex9tdj?file=app%2Fpage.module.css)
![shot-mTFxVBKN@2x](https://github.com/user-attachments/assets/88b0251b-ab8c-4e8f-b70a-e16120dca310)

I took a look and found out the reason:

without postcss-nesting the selector is `button`  (which is not pure)
with postcss-nesting the selector is `.page button` (which **IS** pure according to postcss-modules-local-by-default)

To proof that I added a new passing test case without modifying the logic:

```js
 {
    name: "consider global inside local as pure",
    input: ".foo button { a_value: some-value; }",
    options: { mode: "pure" },
    expected: ":local(.foo) button { a_value: some-value; }",
  },
```

