### PR TITLE
add global for animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Transformation examples:
 
+Selectors (mode `local`, by default)::
+
 <!-- prettier-ignore-start -->
 ```css
 .foo { ... } /* => */ :local(.foo) { ... }
@@ -25,6 +27,30 @@ Transformation examples:
 .foo :global(.bar) .baz { ... } /* => */ :local(.foo) .bar :local(.baz) { ... }
 
 .foo:global(.bar) .baz { ... } /* => */ :local(.foo).bar :local(.baz) { ... }
+```
+<!-- prettier-ignore-end -->
+
+Declarations (mode `local`, by default):
+
+<!-- prettier-ignore-start -->
+```css
+.foo {
+  animation-name: fadeInOut, global(moveLeft300px), local(bounce);
+}
+
+.bar {
+  animation: rotate 1s, global(spin) 3s, local(fly) 6s;
+}
+
+/* => */ 
+
+:local(.foo) {
+  animation-name: :local(fadeInOut), moveLeft300px, :local(bounce);
+}
+
+:local(.bar) {
+  animation: :local(rotate) 1s, spin 3s, :local(fly) 6s;
+}
 ```
 <!-- prettier-ignore-end -->
 

--- a/src/index.js
+++ b/src/index.js
@@ -328,6 +328,17 @@ function localizeDeclarationValues(localize, declaration, context) {
       return false;
     }
 
+    // replace `animation-name: global(example)` with `animation-name: example`
+    if (
+      node.type === "function" &&
+      node.value.toLowerCase() === "global" &&
+      /animation(-name)$/i.test(declaration.prop) &&
+      node.nodes.length === 1
+    ) {
+      Object.assign(node, node.nodes[0]);
+      return;
+    }
+
     if (
       node.type === "word" &&
       specialKeywords.includes(node.value.toLowerCase())
@@ -414,9 +425,13 @@ function localizeDeclaration(declaration, context) {
         parsedAnimationKeywords = {};
 
         return;
-      }
-      // Do not handle nested functions
-      else if (node.type === "function") {
+      } else if (node.type === "function") {
+        // replace `animation: global(example)` with `animation-name: example`
+        if (node.value.toLowerCase() === "global" && node.nodes.length === 1) {
+          Object.assign(node, node.nodes[0]);
+          return false;
+        }
+        // Do not handle nested functions
         return false;
       }
       // Ignore all except word

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -165,6 +165,11 @@ const tests = [
     expected: ":local(.foo) { animation-name: :local(bar); }",
   },
   {
+    name: "localize a single animation-name #2",
+    input: ".foo { animation-name: local(bar); }",
+    expected: ":local(.foo) { animation-name: :local(bar); }",
+  },
+  {
     name: "not localize animation-name in a var function",
     input: ".foo { animation-name: var(--bar); }",
     expected: ":local(.foo) { animation-name: var(--bar); }",
@@ -185,6 +190,29 @@ const tests = [
     expected: ":local(.foo) { animation-name: bar; }",
   },
   {
+    name: "localize and not localize animation-name in mixed case",
+    input:
+      ".foo { animation-name: fadeInOut, global(moveLeft300px), local(bounce); }",
+    expected:
+      ":local(.foo) { animation-name: :local(fadeInOut), moveLeft300px, :local(bounce); }",
+  },
+  {
+    name: "localize and not localize animation-name in mixed case #2",
+    options: { mode: "global" },
+    input:
+      ".foo { animation-name: fadeInOut, global(moveLeft300px), local(bounce); }",
+    expected:
+      ".foo { animation-name: fadeInOut, moveLeft300px, :local(bounce); }",
+  },
+  {
+    name: "localize and not localize animation-name in mixed case #3",
+    options: { mode: "pure" },
+    input:
+      ".foo { animation-name: fadeInOut, global(moveLeft300px), local(bounce); }",
+    expected:
+      ":local(.foo) { animation-name: :local(fadeInOut), moveLeft300px, :local(bounce); }",
+  },
+  {
     name: "not localize animation in an global function",
     input: ".foo { animation: global(bar); }",
     expected: ":local(.foo) { animation: bar; }",
@@ -193,6 +221,25 @@ const tests = [
     name: "not localize a certain animation in an global function",
     input: ".foo { animation: global(bar), foo; }",
     expected: ":local(.foo) { animation: bar, :local(foo); }",
+  },
+  {
+    name: "localize and not localize a certain animation in mixed case",
+    input: ".foo { animation: rotate 1s, global(spin) 3s, local(fly) 6s; }",
+    expected:
+      ":local(.foo) { animation: :local(rotate) 1s, spin 3s, :local(fly) 6s; }",
+  },
+  {
+    name: "localize and not localize a certain animation in mixed case #2",
+    options: { mode: "global" },
+    input: ".foo { animation: rotate 1s, global(spin) 3s, local(fly) 6s; }",
+    expected: ".foo { animation: rotate 1s, spin 3s, :local(fly) 6s; }",
+  },
+  {
+    name: "localize and not localize a certain animation in mixed case #2",
+    options: { mode: "pure" },
+    input: ".foo { animation: rotate 1s, global(spin) 3s, local(fly) 6s; }",
+    expected:
+      ":local(.foo) { animation: :local(rotate) 1s, spin 3s, :local(fly) 6s; }",
   },
   {
     name: "not localize animation-name in an env function #2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -180,6 +180,21 @@ const tests = [
     expected: ":local(.foo) { animation-name: env(bar); }",
   },
   {
+    name: "not localize animation-name in an global function",
+    input: ".foo { animation-name: global(bar); }",
+    expected: ":local(.foo) { animation-name: bar; }",
+  },
+  {
+    name: "not localize animation in an global function",
+    input: ".foo { animation: global(bar); }",
+    expected: ":local(.foo) { animation: bar; }",
+  },
+  {
+    name: "not localize a certain animation in an global function",
+    input: ".foo { animation: global(bar), foo; }",
+    expected: ":local(.foo) { animation: bar, :local(foo); }",
+  },
+  {
     name: "not localize animation-name in an env function #2",
     input: ".foo { animation-name: eNv(bar); }",
     expected: ":local(.foo) { animation-name: eNv(bar); }",


### PR DESCRIPTION
add support for the `global()` function in `animation` and `animation-name` properties

the change modifies the `localizeDeclarationValues` function to handle the `global()` function specifically for animation properties:

```js
// Add check for global() in animation properties
if (node.type === "function" && 
    node.value.toLowerCase() === "global" && 
    /animation(-name)?$/i.test(declaration.prop) && 
    node.nodes.length === 1) {
  Object.assign(node, node.nodes[0]);
  return;
}
```

This allows us to:
1. Detect `global()` usage in animation properties
2. Extract the animation name from within the `global()` wrapper
3. Prevent the animation name from being localized
4. Preserve all other animation properties

## Examples

```css
.component {
  animation: global(fadeIn) 0.5s ease-in;
  /* or */
  animation-name: global(fadeIn);
}
```

## Testing
Added test cases to verify:
- `global()` function works with `animation-name` property
- Existing functionality remains unchanged

fixes #75