### PR TITLE
add pure ignore comment for CSS Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Declarations (mode `local`, by default):
 ```
 <!-- prettier-ignore-end -->
 
+## Pure Mode
+
+In pure mode, all selectors must contain at least one local class or id
+selector
+
+To ignore this rule for a specific selector, add the following comment in front
+of the selector:
+
+```css
+/* cssmodules-pure-ignore */
+:global(#modal-backdrop) {
+  ...;
+}
+```
+
 ## Building
 
 ```bash

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -949,7 +949,15 @@ const tests = [
     options: { mode: "pure" },
     input: `/* cssmodules-pure-ignore */
             :global(.foo) { color: blue; }`,
-    expected: `/* cssmodules-pure-ignore */
+    expected: `.foo { color: blue; }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #2",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            /* another comment */
+            :global(.foo) { color: blue; }`,
+    expected: `/* another comment */
             .foo { color: blue; }`,
   },
   {
@@ -957,8 +965,7 @@ const tests = [
     options: { mode: "pure" },
     input: `/* cssmodules-pure-ignore - needed for third party integration */
             :global(#foo) { color: blue; }`,
-    expected: `/* cssmodules-pure-ignore - needed for third party integration */
-            #foo { color: blue; }`,
+    expected: `#foo { color: blue; }`,
   },
   {
     name: "should not affect rules after the ignored block",
@@ -985,9 +992,7 @@ const tests = [
               /* cssmodules-pure-ignore */
               :global(.bar) { color: blue; }
             }`,
-    expected: `/* cssmodules-pure-ignore */
-            .foo {
-              /* cssmodules-pure-ignore */
+    expected: `.foo {
               .bar { color: blue; }
             }`,
   },
@@ -998,8 +1003,7 @@ const tests = [
             ::view-transition-group(modal) {
               animation-duration: 300ms;
             }`,
-    expected: `/* cssmodules-pure-ignore */
-            ::view-transition-group(modal) {
+    expected: `::view-transition-group(modal) {
               animation-duration: 300ms;
             }`,
   },
@@ -1011,8 +1015,7 @@ const tests = [
               from { opacity: 1; }
               to { opacity: 0; }
             }`,
-    expected: `/* cssmodules-pure-ignore */
-            @keyframes fadeOut {
+    expected: `@keyframes fadeOut {
               from { opacity: 1; }
               to { opacity: 0; }
             }`,
@@ -1025,7 +1028,6 @@ const tests = [
               :global(.foo) { color: blue; }
             }`,
     expected: `@media (min-width: 768px) {
-              /* cssmodules-pure-ignore */
               .foo { color: blue; }
             }`,
   },
@@ -1037,10 +1039,8 @@ const tests = [
             .local { color: green; }
             /* cssmodules-pure-ignore */
             :global(.bar) { color: red; }`,
-    expected: `/* cssmodules-pure-ignore */
-            .foo { color: blue; }
+    expected: `.foo { color: blue; }
             :local(.local) { color: green; }
-            /* cssmodules-pure-ignore */
             .bar { color: red; }`,
   },
   {
@@ -1050,8 +1050,7 @@ const tests = [
             :global(.foo):hover > :global(.bar) + :global(.baz) {
               color: blue;
             }`,
-    expected: `/* cssmodules-pure-ignore */
-            .foo:hover > .bar + .baz {
+    expected: `.foo:hover > .bar + .baz {
               color: blue;
             }`,
   },
@@ -1064,8 +1063,7 @@ const tests = [
             :global(.baz) {
               color: blue;
             }`,
-    expected: `/* cssmodules-pure-ignore */
-            .foo,
+    expected: `.foo,
             .bar,
             .baz {
               color: blue;
@@ -1079,8 +1077,7 @@ const tests = [
             :global(.foo)::after {
               content: '';
             }`,
-    expected: `/* cssmodules-pure-ignore */
-            .foo::before,
+    expected: `.foo::before,
             .foo::after {
               content: '';
             }`,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -961,6 +961,57 @@ const tests = [
             .foo { color: blue; }`,
   },
   {
+    name: "should suppress errors for global selectors after ignore comment #3",
+    options: { mode: "pure" },
+    input: `/* another comment */
+            /* cssmodules-pure-ignore */
+            :global(.foo) { color: blue; }`,
+    expected: `/* another comment */
+            .foo { color: blue; }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #4",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */ /* another comment */
+            :global(.foo) { color: blue; }`,
+    expected: `/* another comment */
+            .foo { color: blue; }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #5",
+    options: { mode: "pure" },
+    input: `/* another comment */ /* cssmodules-pure-ignore */
+            :global(.foo) { color: blue; }`,
+    expected: `/* another comment */
+            .foo { color: blue; }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #6",
+    options: { mode: "pure" },
+    input: `.foo { /* cssmodules-pure-ignore */ :global(.bar) { color: blue }; }`,
+    expected: `:local(.foo) { .bar { color: blue }; }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #7",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */ :global(.foo) { /* cssmodules-pure-ignore */ :global(.bar) { color: blue } }`,
+    expected: `.foo { .bar { color: blue } }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #8",
+    options: { mode: "pure" },
+    input: `/*     cssmodules-pure-ignore     */ :global(.foo) { color: blue; }`,
+    expected: `.foo { color: blue; }`,
+  },
+  {
+    name: "should suppress errors for global selectors after ignore comment #9",
+    options: { mode: "pure" },
+    input: `/*
+    cssmodules-pure-ignore
+    */ :global(.foo) { color: blue; }`,
+    expected: `.foo { color: blue; }`,
+  },
+  {
     name: "should allow additional text in ignore comment",
     options: { mode: "pure" },
     input: `/* cssmodules-pure-ignore - needed for third party integration */
@@ -1019,6 +1070,45 @@ const tests = [
               from { opacity: 1; }
               to { opacity: 0; }
             }`,
+  },
+  {
+    name: "should work with scope in ignored block",
+    options: { mode: "pure" },
+    input: `
+/* cssmodules-pure-ignore */
+@scope (:global(.foo)) to (:global(.bar)) {
+  .article-footer {
+    border: 5px solid black;
+  }
+}
+`,
+    expected: `
+@scope (.foo) to (.bar) {
+  :local(.article-footer) {
+    border: 5px solid black;
+  }
+}
+`,
+  },
+  {
+    name: "should work with scope in ignored block #2",
+    options: { mode: "pure" },
+    input: `
+/* cssmodules-pure-ignore */
+@scope (:global(.foo))
+ to (:global(.bar)) {
+  .article-footer {
+    border: 5px solid black;
+  }
+}
+`,
+    expected: `
+@scope (.foo) to (.bar) {
+  :local(.article-footer) {
+    border: 5px solid black;
+  }
+}
+`,
   },
   {
     name: "should work in media queries",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -945,6 +945,147 @@ const tests = [
     error: /is not pure/,
   },
   {
+    name: "should suppress errors for global selectors after ignore comment",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo) { color: blue; }`,
+    expected: `/* cssmodules-pure-ignore */
+            .foo { color: blue; }`,
+  },
+  {
+    name: "should allow additional text in ignore comment",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore - needed for third party integration */
+            :global(#foo) { color: blue; }`,
+    expected: `/* cssmodules-pure-ignore - needed for third party integration */
+            #foo { color: blue; }`,
+  },
+  {
+    name: "should not affect rules after the ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo) { color: blue; }
+            :global(.bar) { color: red; }`,
+    error: /is not pure/,
+  },
+  {
+    name: "should work with nested global selectors in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo) {
+              :global(.bar) { color: blue; }
+            }`,
+    error: /is not pure/,
+  },
+  {
+    name: "should work with ignored nested global selectors in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo) {
+              /* cssmodules-pure-ignore */
+              :global(.bar) { color: blue; }
+            }`,
+    expected: `/* cssmodules-pure-ignore */
+            .foo {
+              /* cssmodules-pure-ignore */
+              .bar { color: blue; }
+            }`,
+  },
+  {
+    name: "should work with view transitions in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            ::view-transition-group(modal) {
+              animation-duration: 300ms;
+            }`,
+    expected: `/* cssmodules-pure-ignore */
+            ::view-transition-group(modal) {
+              animation-duration: 300ms;
+            }`,
+  },
+  {
+    name: "should work with keyframes in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            @keyframes :global(fadeOut) {
+              from { opacity: 1; }
+              to { opacity: 0; }
+            }`,
+    expected: `/* cssmodules-pure-ignore */
+            @keyframes fadeOut {
+              from { opacity: 1; }
+              to { opacity: 0; }
+            }`,
+  },
+  {
+    name: "should work in media queries",
+    options: { mode: "pure" },
+    input: `@media (min-width: 768px) {
+              /* cssmodules-pure-ignore */
+              :global(.foo) { color: blue; }
+            }`,
+    expected: `@media (min-width: 768px) {
+              /* cssmodules-pure-ignore */
+              .foo { color: blue; }
+            }`,
+  },
+  {
+    name: "should handle multiple ignore comments",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo) { color: blue; }
+            .local { color: green; }
+            /* cssmodules-pure-ignore */
+            :global(.bar) { color: red; }`,
+    expected: `/* cssmodules-pure-ignore */
+            .foo { color: blue; }
+            :local(.local) { color: green; }
+            /* cssmodules-pure-ignore */
+            .bar { color: red; }`,
+  },
+  {
+    name: "should work with complex selectors in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo):hover > :global(.bar) + :global(.baz) {
+              color: blue;
+            }`,
+    expected: `/* cssmodules-pure-ignore */
+            .foo:hover > .bar + .baz {
+              color: blue;
+            }`,
+  },
+  {
+    name: "should work with multiple selectors in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo),
+            :global(.bar),
+            :global(.baz) {
+              color: blue;
+            }`,
+    expected: `/* cssmodules-pure-ignore */
+            .foo,
+            .bar,
+            .baz {
+              color: blue;
+            }`,
+  },
+  {
+    name: "should work with pseudo-elements in ignored block",
+    options: { mode: "pure" },
+    input: `/* cssmodules-pure-ignore */
+            :global(.foo)::before,
+            :global(.foo)::after {
+              content: '';
+            }`,
+    expected: `/* cssmodules-pure-ignore */
+            .foo::before,
+            .foo::after {
+              content: '';
+            }`,
+  },
+  {
     name: "css nesting",
     input: `
 .foo {


### PR DESCRIPTION
Add support for selectively opting out of pure CSS Module requirements via `/* cssmodules-pure-ignore */` comments 

- Comments only affect the immediately following rule or declaration
- Parent selectors with ignore comments still localize their children
- Properties following an ignored property are re-localized
- The implementation uses PostCSS's comment tracking capabilities for minimal performance impact

Initially I started with the `@` prefix (`@cssmodules-pure-ignore`), but removed based on feedback from @jaggli for cleaner syntax.

fixes #78 

#### Examples

```css
/* cssmodules-pure-ignore */
#third-party-modal-backdrop {
  background: rgba(0, 0, 0, 0.5);
}

.component {
  /* cssmodules-pure-ignore */
  animation-name: fade-out;
  &.isActive { /* <-- still locally scoped */
     animation-name: disabled;  /*  <-- still locally scoped */
  }
}
```

The comment can include additional explanation text:
```css
/* cssmodules-pure-ignore Modal styling injected into body */
#payment-modal { ... }
```

#### Test Cases

- Basic ignore functionality for selectors
- Animation property handling
- Nested selector behavior
- Comment scope boundaries
- Comments with additional explanation text
- Mixed local/global rules

Please let me know if you have more ideas for tests
